### PR TITLE
Remove some lingering ignitions

### DIFF
--- a/kortex_description/grippers/robotiq_2f_140/urdf/robotiq_2f_140_macro.xacro
+++ b/kortex_description/grippers/robotiq_2f_140/urdf/robotiq_2f_140_macro.xacro
@@ -27,7 +27,7 @@
         com_port="${com_port}"
         use_fake_hardware="${use_fake_hardware}"
         fake_sensor_commands="${fake_sensor_commands}"
-        sim_ignition="${sim_gazebo}"
+        sim_gazebo="${sim_gazebo}"
         sim_isaac="${sim_isaac}"
         isaac_joint_commands="${isaac_joint_commands}"
         isaac_joint_states="${isaac_joint_states}">

--- a/kortex_description/grippers/robotiq_2f_85/urdf/robotiq_2f_85_macro.xacro
+++ b/kortex_description/grippers/robotiq_2f_85/urdf/robotiq_2f_85_macro.xacro
@@ -27,7 +27,7 @@
         com_port="${com_port}"
         use_fake_hardware="${use_fake_hardware}"
         fake_sensor_commands="${fake_sensor_commands}"
-        sim_ignition="${sim_gazebo}"
+        sim_gazebo="${sim_gazebo}"
         sim_isaac="${sim_isaac}"
         isaac_joint_commands="${isaac_joint_commands}"
         isaac_joint_states="${isaac_joint_states}">


### PR DESCRIPTION
:crossed_fingers: 

https://github.com/moveit/moveit2_tutorials/actions/runs/10087425937/job/27891565916?pr=921

We get an error in the Quickstart in RViz test due to invalid parameter:
```
- doc_tutorials_quickstart_in_rviz_test_bringup_test.test.py
  <<< failure message
    -- run_test.py: invoking following command in '/home/runner/work/moveit2_tutorials/moveit2_tutorials/.work/target_ws/build/moveit2_tutorials/doc/tutorials/quickstart_in_rviz':
     - ros2 test /home/runner/work/moveit2_tutorials/moveit2_tutorials/.work/target_ws/src/moveit2_tutorials/doc/tutorials/quickstart_in_rviz/test/bringup_test.test.py test_binary_dir:=/home/runner/work/moveit2_tutorials/moveit2_tutorials/.work/target_ws/build/moveit2_tutorials/doc/tutorials/quickstart_in_rviz --junit-xml=/home/runner/work/moveit2_tutorials/moveit2_tutorials/.work/target_ws/build/moveit2_tutorials/test_results/moveit2_tutorials/doc_tutorials_quickstart_in_rviz_test_bringup_test.test.py.xunit.xml --package-name=moveit2_tutorials
    Running with ROS_DOMAIN_ID 1
    ROS_DOMAIN_ID 1
    [INFO] [launch]: All log files can be found below /root/.ros/log/2024-07-25-03-19-53-067385-63bb9e84ff5c-17029
    [INFO] [launch]: Default logging verbosity is set to INFO
Error: ROR] [launch]: Caught exception in launch (see debug for traceback): Invalid parameter "sim_ignition"
    Processes under test stopped before tests completed
```